### PR TITLE
Fix for pathExtension no longer available in Swift 2.0's String struct.

### DIFF
--- a/NSData+Compression/NSData+Compression.swift
+++ b/NSData+Compression/NSData+Compression.swift
@@ -68,7 +68,7 @@ extension NSData {
 		}
 		else {
 			// otherwise, attempt to use the file extension to determine the compression algorithm
-			switch path.pathExtension.lowercaseString {
+			switch (path as NSString).pathExtension.lowercaseString {
 			case "lz4"  :	compression = Compression.LZ4
 			case "zlib" :	compression = Compression.ZLIB
 			case "lzma" :	compression = Compression.LZMA


### PR DESCRIPTION
Since Swift 2.0, the pathExtension property, is no longer available in the String struct. Fixed as a cast to NSString.
